### PR TITLE
Hash passwords en registro, cambio de contraseña y login (v2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./sgi/src:/var/www/html
     ports:
       - 8000:80
+    command: bash -c "php -f update_passwords.php && docker-php-entrypoint apache2-foreground"
   mysql:
     image: mysql:5.6
     container_name: sgi_mysql

--- a/sgi/src/cambiarpwd.php
+++ b/sgi/src/cambiarpwd.php
@@ -71,12 +71,12 @@
 			$conexion->Ejecuto("select Password from socio where idSocio=" . $idSocio);
 			$socio=$conexion->Siguiente();
 			
-			if ($socio['Password'] == $pwdActual){ //SI COINCIDEN, SE CAMBIA EL PWD
+			if (password_verify($pwdActual, $socio['Password'])){ //SI COINCIDEN, SE CAMBIA EL PWD
 				$conexion->Ejecuto("update socio set Password='" . crypt($pwdNueva) . "' where idSocio=" . $idSocio);
 			
 				$tpl->NewBlock("mensaje");
 				$tpl->Assign("mensaje", utf8_encode("La contraseña se modificó correctamente."));
-			} elseif ($socio['Password'] != $pwdActual) { //SI NO COINCIDEN, SE MUESTRA MENSAJE
+			} else { //SI NO COINCIDEN, SE MUESTRA MENSAJE
 				$tpl->NewBlock("mensaje");
 				$tpl->Assign("mensaje", utf8_encode("La contraseña actual ingresada no coincide con la almacenada en la base de datos"));
 			}

--- a/sgi/src/cambiarpwd.php
+++ b/sgi/src/cambiarpwd.php
@@ -72,7 +72,7 @@
 			$socio=$conexion->Siguiente();
 			
 			if ($socio['Password'] == $pwdActual){ //SI COINCIDEN, SE CAMBIA EL PWD
-				$conexion->Ejecuto("update socio set Password='" . $pwdNueva . "' where idSocio=" . $idSocio);
+				$conexion->Ejecuto("update socio set Password='" . crypt($pwdNueva) . "' where idSocio=" . $idSocio);
 			
 				$tpl->NewBlock("mensaje");
 				$tpl->Assign("mensaje", utf8_encode("La contraseña se modificó correctamente."));
@@ -101,3 +101,4 @@
 		return $periodo['idPeriodo'];
 	}
 ?>
+

--- a/sgi/src/login.php
+++ b/sgi/src/login.php
@@ -20,9 +20,9 @@
 		$pwd=$_POST['pwd'];
 		$conexion->Ejecuto("select idSocio, Activo, Password from socio where Email='" . $direccion . "'");
 		$socio=$conexion->Siguiente();
-		$checkPassword=password_verify($pwd, $socio["Password"]);
+		$isPasswordValid=password_verify($pwd, $socio["Password"]);
 
-		if ($checkPassword){
+		if ($isPasswordValid){
 			if ($socio['Activo'] == 0){
 				$tpl->NewBlock("mensaje");
 				$tpl->Assign("mensaje", "Tu cuenta est� desactivada");

--- a/sgi/src/login.php
+++ b/sgi/src/login.php
@@ -18,10 +18,11 @@
 	if ($accion == "login"){
 		$direccion=$_POST['mail'];
 		$pwd=$_POST['pwd'];
-		$conexion->Ejecuto("select idSocio, Activo from socio where Email='" . $direccion . "' and Password='" . $pwd . "'");
+		$conexion->Ejecuto("select idSocio, Activo, Password from socio where Email='" . $direccion . "'");
 		$socio=$conexion->Siguiente();
+		$checkPassword=password_verify($pwd, $socio["Password"]);
 
-		if ($socio['idSocio'] != ""){
+		if ($checkPassword){
 			if ($socio['Activo'] == 0){
 				$tpl->NewBlock("mensaje");
 				$tpl->Assign("mensaje", "Tu cuenta est� desactivada");

--- a/sgi/src/preregistro.php
+++ b/sgi/src/preregistro.php
@@ -72,7 +72,7 @@
 			$fechaN = split("/", $fechaNac);
 
 			//insertar usuario inactivo hasta confirmar mail
-			$conexion->Ejecuto("insert into preregistro (Nombres, Apellidos, Documento, Direccion, Ciudad, ViveCon, Hospeda, FechaNac, Sexo, Email, Password, Telefono, AreaEstudio, Trabajo, Facebook, FechaRegistro,idTransaccion) values ('" . $nombres . "','" . $apellidos . "'," . $documento . ",'" . $direccionF . "','" . $ciudad . "','" . $viveCon . "'," . $hospeda . ",'" . $fechaN[2] . $fechaN[1] . $fechaN[0] . "'," . $sexo . ",'" . $direccion . "','" . $pwd . "','" . $telefono . "','" . $ocupacion . "','" . $trabajo . "','" . $facebook . "','" . date("Y-m-d H:i:s") . "'," . $idTransaccion . ")");
+			$conexion->Ejecuto("insert into preregistro (Nombres, Apellidos, Documento, Direccion, Ciudad, ViveCon, Hospeda, FechaNac, Sexo, Email, Password, Telefono, AreaEstudio, Trabajo, Facebook, FechaRegistro,idTransaccion) values ('" . $nombres . "','" . $apellidos . "'," . $documento . ",'" . $direccionF . "','" . $ciudad . "','" . $viveCon . "'," . $hospeda . ",'" . $fechaN[2] . $fechaN[1] . $fechaN[0] . "'," . $sexo . ",'" . $direccion . "','" . crypt($pwd) . "','" . $telefono . "','" . $ocupacion . "','" . $trabajo . "','" . $facebook . "','" . date("Y-m-d H:i:s") . "'," . $idTransaccion . ")");
 			
 			//Envío correo de confirmación
 			$cuerpo = "Para continuar tu registro en SGI, hace click <a href='http://sgi.airaup.org/confirmacion.php?id=" . $idTransaccion . "'>aquí</a>.<br><br>Por favor no respondas este mensaje.<br>Sistema de Gestión Integral<br>AIRAUP";

--- a/sgi/src/update_passwords.php
+++ b/sgi/src/update_passwords.php
@@ -1,0 +1,48 @@
+<?php
+    ini_set("display_errors", 0);
+    include("config.php");
+    require_once("conexionDB.php");
+    session_start();
+
+    // Constants
+    $LENGTH_PASSWORD_HASHED = 34;
+    $REGEX_PASSWORD_HASHED = "\$\d+\$";
+
+    echo "Start hashing passwords";
+
+    // Get DB instances to start to operate.
+    $connectionRead = getInstanceDB();
+    $connectionWrite = getInstanceDB();
+
+    $connectionRead -> Ejecuto("select idSocio, Password from socio;");
+    while ($socio = $connectionRead->Siguiente()) {
+        if (!passwordIsHashed($socio["Password"])) {
+            $connectionWrite -> Ejecuto(
+                "update socio set Password='" . crypt($socio["Password"]) . "' where idSocio=" . $socio["idSocio"]);
+        }
+    }
+
+    $connectionRead -> Ejecuto("select idPreRegistro, Password from preregistro;");
+    while ($preregistro = $connectionRead->Siguiente()) {
+        if (!passwordIsHashed($socio["Password"])) {
+            $connectionWrite -> Ejecuto(
+                "update preregistro set Password='" . crypt($preregistro["Password"]) . "' where idPreRegistro=" . $preregistro["idPreRegistro"]);
+        }
+    }
+
+    echo "All passwords were hashed.";
+
+    function passwordIsHashed ($password) {
+        return strlen($password) == $LENGTH_PASSWORD_HASHED && (preg_match($REGEX_PASSWORD_HASHED, $password) == 1);
+    }
+
+    function getInstanceDB () {
+        $obj_con = new conectar;
+        return new ConexionDB(
+            $obj_con -> getServ(),
+            $obj_con -> getBase(),
+            $obj_con -> getUsr(),
+            $obj_con->  getPass()
+        );
+    }
+?>


### PR DESCRIPTION
Se creo un script en php para actualizar passwords de texto plano a passwords hasheadas.
Implementacion del metodo crypt() en las operaciones de preregistro y reset password.
Implementacion de password_verify() en operaciones de login y reset password.